### PR TITLE
BE01 - fixed error at window shell

### DIFF
--- a/01-task-tracker-cli/app.js
+++ b/01-task-tracker-cli/app.js
@@ -7,9 +7,7 @@ switch (args[0]) {
         if (args.length === 1) {
             taskManager.viewTasks(null);
         } else if (!["todo", "in-progress", "done"].includes(args[1])) {
-            console.log(
-                "Invalid status provided. Valid status: todo, in-progress, done"
-            );
+            console.log("Invalid status provided. Valid status: todo, in-progress, done");
             process.exit(1);
         } else {
             taskManager.viewTasks(args[1]);

--- a/01-task-tracker-cli/src/task-utils.js
+++ b/01-task-tracker-cli/src/task-utils.js
@@ -19,16 +19,29 @@ export function init() {
     try {
         if (!fs.existsSync(filePath)) {
             // make directory data
+            console.log("Creating folder data...");
             fs.mkdirSync(DATA_PATH);
             // create file
+            console.log("Creating data file...");
             let fileData = {
                 tasks: [],
                 totalTask: 0,
             };
             fs.writeFileSync(filePath, JSON.stringify(fileData, null, 4), "utf8");
+
+            console.log("Data file created at: " + filePath);
         }
     } catch (error) {
-        console.log(error);
+        console.log("Folder exist! Creating data file...");
+
+        // create files if folder exist
+        let fileData = {
+            tasks: [],
+            totalTask: 0,
+        };
+        fs.writeFileSync(filePath, JSON.stringify(fileData, null, 4), "utf8");
+
+        console.log("Data file created at: " + filePath);
     }
 }
 


### PR DESCRIPTION
When running at window shell, if folder data exist but file data doesn't exist => error fired when create folder data

- [x] Fixed by catching when error fired => create file data at here
- [x] Add some comments and log when initial data folder and file.